### PR TITLE
Enable xwayland support on weston

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+weston (12.0.4+git20240528.461c49d-0+toradex2) bookworm; urgency=medium
+
+  * Team upload.
+  * Enable Xwayland support on weston.
+      - d/control: add needed build and run-time dependencies;
+      - d/libweston-12-0.install: install xwayland module;
+      - d/rules: enable Xwayland support.
+
+ -- Carlos Henrique Lima Melara <carlos.melara@toradex.com>  Tue, 05 Nov 2024 15:15:14 -0300
+
 weston (12.0.4+git20240528.461c49d-0+toradex1) bookworm; urgency=medium
 
   * New upstream version 12.0.4+git20240528.461c49d

--- a/debian/control
+++ b/debian/control
@@ -20,8 +20,8 @@ Build-Depends: debhelper (>= 10),
                liblcms2-dev,
                libpam0g-dev,
                libpango1.0-dev,
-               libpixman-1-dev (>= 0.25.2),
                libpipewire-0.3-dev,
+               libpixman-1-dev (>= 0.25.2),
                libpng-dev,
                libseat-dev,
                libsystemd-dev,
@@ -33,6 +33,7 @@ Build-Depends: debhelper (>= 10),
                libx11-dev,
                libx11-xcb-dev,
                libxcb-composite0-dev,
+               libxcb-cursor-dev,
                libxcb-shape0-dev,
                libxcb-xfixes0-dev,
                libxcb-xkb-dev,
@@ -58,6 +59,7 @@ Vcs-Browser: https://salsa.debian.org/xorg-team/wayland/weston
 Package: weston
 Architecture: linux-any
 Depends: adduser,
+         xwayland,
          ${misc:Depends},
          ${shlibs:Depends}
 Breaks: libweston-8-dev

--- a/debian/libweston-12-0.install
+++ b/debian/libweston-12-0.install
@@ -7,5 +7,6 @@ usr/lib/*/libweston-12/rdp-backend.so
 usr/lib/*/libweston-12/vnc-backend.so
 usr/lib/*/libweston-12/wayland-backend.so
 usr/lib/*/libweston-12/x11-backend.so
+usr/lib/*/libweston-12/xwayland.so
 usr/lib/*/libweston-12/pipewire-backend.so
 usr/lib/*/libweston-12/g2d-renderer.so

--- a/debian/rules
+++ b/debian/rules
@@ -11,7 +11,7 @@ override_dh_auto_configure:
                 -Dcolor-management-lcms=false \
                 -Dbackend-drm-screencast-vaapi=false \
                 -Drenderer-g2d=true \
-                -Dxwayland=false \
+                -Dxwayland=true \
                 -Dimage-jpeg=true
 
 override_dh_auto_test:


### PR DESCRIPTION
Requires updated imx-gpu-viv package hitting our feeds first (torizon/imx-gpu-viv-deb#4) so it can build successfully.